### PR TITLE
Need to request BODY_SENSORS permission in mobile application

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.marctan.hrmtest" >
 
+    <uses-permission android:name="android.permission.BODY_SENSORS" />
+
     <application
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"


### PR DESCRIPTION
Need to request BODY_SENSORS permission in mobile application, since the Android Wear companion requires the mobile app to have the same or more permissions than the wearable app. Otherwise this app will not install from the Play Store or when built in release mode and installed to the phone.

It is ok to request BODY_SENSORS on API 19 devices, even though it is not available on this device.
