### PR TITLE
Fixed compile error "Error:(16, 0) Gradle DSL method not found: 'runProg...

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -13,7 +13,7 @@ android {
     }
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -14,7 +14,7 @@ android {
     }
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }


### PR DESCRIPTION
...uard()'"

Instead of using runProguard in your gradle file, try using minifyEnabled.
This should fix the issue. runProguard is deprecated and soon be stop working.
